### PR TITLE
Use --no-renames to prevent renames from messing up the tree

### DIFF
--- a/main.js
+++ b/main.js
@@ -7,7 +7,7 @@ const drawTree = require('./src/drawTree');
 const print = require('./src/print');
 
 const execDiffandDrawTree = (branchB) => {
-  exec(`git diff --name-status ${diffAgainstBranch}...${branchB}`, (err, stdout, stderr) => {
+  exec(`git diff --name-status --no-renames ${diffAgainstBranch}...${branchB}`, (err, stdout, stderr) => {
     const changes = diffStrToChanges(stdout);
     const treeData = tree(changes);
     console.log(drawTree(treeData));


### PR DESCRIPTION
This change will list them as a Deletion and an Add. I don't have a good UI for renames at the moment, but I think there's probably a better one than this. However, currently renames just look broken so this should at least not show anything inaccurate.